### PR TITLE
Parser

### DIFF
--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -17,12 +17,12 @@ type Expression interface {
 }
 
 type Program struct {
-	Statement []Statement
+	Statements []Statement
 }
 
 func (p *Program) TokenLiteral() string {
-	if len(p.Statement) > 0 {
-		return p.Statement[0].TokenLiteral()
+	if len(p.Statements) > 0 {
+		return p.Statements[0].TokenLiteral()
 	} else {
 		return ""
 	}

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -1,0 +1,52 @@
+package ast
+
+import "github.com/gargalloeric/monkey/internal/token"
+
+type Node interface {
+	TokenLiteral() string
+}
+
+type Statement interface {
+	Node
+	statementNode()
+}
+
+type Expression interface {
+	Node
+	expressionNode()
+}
+
+type Program struct {
+	Statement []Statement
+}
+
+func (p *Program) TokenLiteral() string {
+	if len(p.Statement) > 0 {
+		return p.Statement[0].TokenLiteral()
+	} else {
+		return ""
+	}
+}
+
+type LetStatement struct {
+	Token token.Token // the token.LET token
+	Name  *Identifier
+	Value Expression
+}
+
+func (l *LetStatement) statementNode() {}
+
+func (l *LetStatement) TokenLiteral() string {
+	return l.Token.Literal
+}
+
+type Identifier struct {
+	Token token.Token // the token token.IDENT token
+	Value string
+}
+
+func (i *Identifier) expressionNode() {}
+
+func (i *Identifier) TokenLiteral() string {
+	return i.Token.Literal
+}

--- a/internal/ast/ast.go
+++ b/internal/ast/ast.go
@@ -50,3 +50,14 @@ func (i *Identifier) expressionNode() {}
 func (i *Identifier) TokenLiteral() string {
 	return i.Token.Literal
 }
+
+type ReturnStatement struct {
+	Token       token.Token // The return token
+	ReturnValue Expression
+}
+
+func (rs *ReturnStatement) TokenLiteral() string {
+	return rs.Token.Literal
+}
+
+func (rs *ReturnStatement) statementNode() {}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -1,6 +1,8 @@
 package parser
 
 import (
+	"fmt"
+
 	"github.com/gargalloeric/monkey/internal/ast"
 	"github.com/gargalloeric/monkey/internal/lexer"
 	"github.com/gargalloeric/monkey/internal/token"
@@ -9,18 +11,33 @@ import (
 type Parser struct {
 	l *lexer.Lexer
 
+	errors []string
+
 	curToken  token.Token
 	peekToken token.Token
 }
 
 func New(l *lexer.Lexer) *Parser {
-	p := &Parser{l: l}
+	p := &Parser{
+		l:      l,
+		errors: []string{},
+	}
 
 	// Read two tokens so current token and peek token are set
 	p.nextToken()
 	p.nextToken()
 
 	return p
+}
+
+func (p *Parser) Errors() []string {
+	return p.errors
+}
+
+func (p *Parser) peekError(t token.TokenType) {
+	msg := fmt.Sprintf("expected next token to be %s, got %s instead", t, p.peekToken.Type)
+	p.errors = append(p.errors, msg)
+
 }
 
 func (p *Parser) nextToken() {
@@ -88,6 +105,7 @@ func (p *Parser) expectPeek(t token.TokenType) bool {
 		p.nextToken()
 		return true
 	} else {
+		p.peekError(t)
 		return false
 	}
 }

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -29,5 +29,65 @@ func (p *Parser) nextToken() {
 }
 
 func (p *Parser) ParseProgram() *ast.Program {
-	return nil
+	program := &ast.Program{}
+	program.Statement = []ast.Statement{}
+
+	for p.curToken.Type != token.EOF {
+		stmt := p.parseStatement()
+		if stmt != nil {
+			program.Statement = append(program.Statement, stmt)
+		}
+
+		p.nextToken()
+	}
+
+	return program
+}
+
+func (p *Parser) parseStatement() ast.Statement {
+	switch p.curToken.Type {
+	case token.LET:
+		return p.parseLetStatement()
+	default:
+		return nil
+	}
+}
+
+func (p *Parser) parseLetStatement() *ast.LetStatement {
+	stmt := &ast.LetStatement{Token: p.curToken}
+
+	if !p.expectPeek(token.IDENT) {
+		return nil
+	}
+
+	stmt.Name = &ast.Identifier{Token: p.curToken, Value: p.curToken.Literal}
+
+	if !p.expectPeek(token.ASSIGN) {
+		return nil
+	}
+
+	// TODO: We're skipping the expressions until we
+	// encounter a semicolon
+	if !p.curTokenIs(token.SEMICOLON) {
+		p.nextToken()
+	}
+
+	return stmt
+}
+
+func (p *Parser) curTokenIs(t token.TokenType) bool {
+	return p.curToken.Type == t
+}
+
+func (p *Parser) peekTokenIs(t token.TokenType) bool {
+	return p.peekToken.Type == t
+}
+
+func (p *Parser) expectPeek(t token.TokenType) bool {
+	if p.peekTokenIs(t) {
+		p.nextToken()
+		return true
+	} else {
+		return false
+	}
 }

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -47,12 +47,12 @@ func (p *Parser) nextToken() {
 
 func (p *Parser) ParseProgram() *ast.Program {
 	program := &ast.Program{}
-	program.Statement = []ast.Statement{}
+	program.Statements = []ast.Statement{}
 
 	for !p.curTokenIs(token.EOF) {
 		stmt := p.parseStatement()
 		if stmt != nil {
-			program.Statement = append(program.Statement, stmt)
+			program.Statements = append(program.Statements, stmt)
 		}
 
 		p.nextToken()

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -1,0 +1,33 @@
+package parser
+
+import (
+	"github.com/gargalloeric/monkey/internal/ast"
+	"github.com/gargalloeric/monkey/internal/lexer"
+	"github.com/gargalloeric/monkey/internal/token"
+)
+
+type Parser struct {
+	l *lexer.Lexer
+
+	curToken  token.Token
+	peekToken token.Token
+}
+
+func New(l *lexer.Lexer) *Parser {
+	p := &Parser{l: l}
+
+	// Read two tokens so current token and peek token are set
+	p.nextToken()
+	p.nextToken()
+
+	return p
+}
+
+func (p *Parser) nextToken() {
+	p.curToken = p.peekToken
+	p.peekToken = p.l.NextToken()
+}
+
+func (p *Parser) ParseProgram() *ast.Program {
+	return nil
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -65,6 +65,8 @@ func (p *Parser) parseStatement() ast.Statement {
 	switch p.curToken.Type {
 	case token.LET:
 		return p.parseLetStatement()
+	case token.RETURN:
+		return p.parseReturnStatement()
 	default:
 		return nil
 	}
@@ -108,4 +110,18 @@ func (p *Parser) expectPeek(t token.TokenType) bool {
 		p.peekError(t)
 		return false
 	}
+}
+
+func (p *Parser) parseReturnStatement() *ast.ReturnStatement {
+	stmt := &ast.ReturnStatement{Token: p.curToken}
+
+	p.nextToken()
+
+	// TODO: We're skipping the expressions until we
+	// encounter a semicolon.
+	for !p.curTokenIs(token.SEMICOLON) {
+		p.nextToken()
+	}
+
+	return stmt
 }

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -32,7 +32,7 @@ func (p *Parser) ParseProgram() *ast.Program {
 	program := &ast.Program{}
 	program.Statement = []ast.Statement{}
 
-	for p.curToken.Type != token.EOF {
+	for !p.curTokenIs(token.EOF) {
 		stmt := p.parseStatement()
 		if stmt != nil {
 			program.Statement = append(program.Statement, stmt)

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -17,6 +17,7 @@ func TestLetStatements(t *testing.T) {
 	parser := New(lexer)
 
 	program := parser.ParseProgram()
+	checkParseErrors(t, parser)
 	if program == nil {
 		t.Fatalf("ParseProgram returned nil")
 	}
@@ -65,4 +66,20 @@ func testLetStatement(t *testing.T, s ast.Statement, name string) bool {
 	}
 
 	return true
+}
+
+func checkParseErrors(t *testing.T, parser *Parser) {
+	t.Helper()
+
+	errors := parser.Errors()
+	if len(errors) == 0 {
+		return
+	}
+
+	t.Errorf("parse has %d errors", len(errors))
+	for _, msg := range errors {
+		t.Errorf("parser error: %q", msg)
+	}
+
+	t.FailNow()
 }

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -83,3 +83,32 @@ func checkParseErrors(t *testing.T, parser *Parser) {
 
 	t.FailNow()
 }
+
+func TestReturnStatements(t *testing.T) {
+	input := `
+	return 5;
+	return 10;
+	return 993322;`
+
+	lexer := lexer.New(input)
+	parser := New(lexer)
+
+	program := parser.ParseProgram()
+	checkParseErrors(t, parser)
+
+	if len(program.Statements) != 3 {
+		t.Fatalf("program.Statements does not contain 3 statements. got=%d", len(program.Statements))
+	}
+
+	for _, stmt := range program.Statements {
+		returnStmt, ok := stmt.(*ast.ReturnStatement)
+		if !ok {
+			t.Errorf("stmt no *ast.ReturnStatement. got=%T", stmt)
+			continue
+		}
+
+		if returnStmt.TokenLiteral() != "return" {
+			t.Errorf("returnStmt.TokenLiteral not 'return', got %q", returnStmt.TokenLiteral())
+		}
+	}
+}

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -22,8 +22,8 @@ func TestLetStatements(t *testing.T) {
 		t.Fatalf("ParseProgram returned nil")
 	}
 
-	if len(program.Statement) != 3 {
-		t.Fatalf("program.Statements does not contain 3 statements. got=%d", len(program.Statement))
+	if len(program.Statements) != 3 {
+		t.Fatalf("program.Statements does not contain 3 statements. got=%d", len(program.Statements))
 	}
 
 	tests := []struct {
@@ -35,7 +35,7 @@ func TestLetStatements(t *testing.T) {
 	}
 
 	for i, tt := range tests {
-		stmt := program.Statement[i]
+		stmt := program.Statements[i]
 		if !testLetStatement(t, stmt, tt.expectedIdentifier) {
 			return
 		}

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -1,0 +1,68 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/gargalloeric/monkey/internal/ast"
+	"github.com/gargalloeric/monkey/internal/lexer"
+)
+
+func TestLetStatements(t *testing.T) {
+	input := `
+	let x = 5;
+	let y = 10;
+	let foobar = 838383;`
+
+	lexer := lexer.New(input)
+	parser := New(lexer)
+
+	program := parser.ParseProgram()
+	if program == nil {
+		t.Fatalf("ParseProgram returned nil")
+	}
+
+	if len(program.Statement) != 3 {
+		t.Fatalf("program.Statements does not contain 3 statements. got=%d", len(program.Statement))
+	}
+
+	tests := []struct {
+		expectedIdentifier string
+	}{
+		{"x"},
+		{"y"},
+		{"foobar"},
+	}
+
+	for i, tt := range tests {
+		stmt := program.Statement[i]
+		if !testLetStatement(t, stmt, tt.expectedIdentifier) {
+			return
+		}
+	}
+}
+
+func testLetStatement(t *testing.T, s ast.Statement, name string) bool {
+	t.Helper()
+	if s.TokenLiteral() != "let" {
+		t.Errorf("s.TokenLiteral not 'let'. got=%q", s.TokenLiteral())
+		return false
+	}
+
+	letStmt, ok := s.(*ast.LetStatement)
+	if !ok {
+		t.Errorf("s not *ast.LetStatement. got=%T", s)
+		return false
+	}
+
+	if letStmt.Name.Value != name {
+		t.Errorf("letSmt.Name.Value not '%s'. got=%s", name, letStmt.Name.Value)
+		return false
+	}
+
+	if letStmt.Name.TokenLiteral() != name {
+		t.Errorf("letSmt.Name.TokenLiteral() not '%s'. got=%s", name, letStmt.Name.TokenLiteral())
+		return false
+	}
+
+	return true
+}


### PR DESCRIPTION
Add statements parsing.

The interpreter now can identify and parse the two statements of the language:

- let
- return

Currently the interpreter is unable to parse expressions so at the moment only identifies the statements and constructs the corresponding AST nodes.